### PR TITLE
feat(backend): add GET /api/v1/tasks endpoint with service and controller

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,7 +1,10 @@
 import express, { Request, Response } from "express";
 import { HealthResponse } from "./types";
+import tasksRouter from "./routes/tasks";
 
 const app = express();
+
+app.use("/api/v1/tasks", tasksRouter);
 
 app.get("/health", (_req: Request, res: Response<HealthResponse>) => {
   res.status(200).json({ status: "ok" });

--- a/backend/src/controllers/taskController.ts
+++ b/backend/src/controllers/taskController.ts
@@ -1,0 +1,7 @@
+import { Request, Response } from "express";
+import { getTasks } from "../services/taskService";
+
+export function getTasksController(req: Request, res: Response) {
+  const data = getTasks();
+  res.status(200).json({ success: true, data });
+}

--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { getTasksController } from "../controllers/taskController";
+
+const router = Router();
+
+router.get("/", getTasksController);
+
+export default router;

--- a/backend/src/services/taskService.ts
+++ b/backend/src/services/taskService.ts
@@ -1,0 +1,5 @@
+import { Task } from "../types";
+
+export function getTasks(): Task[] {
+  return [];
+}


### PR DESCRIPTION
## What does this PR do?

Adds the first data endpoint to the backend — `GET /api/v1/tasks` — wired up through a layered service/controller/router architecture. The endpoint returns `{ success: true, data: [] }` and is ready to be connected to a real data source.

Closes #10

## Changes

### New files
- `backend/src/services/taskService.ts` — `getTasks()` returns a typed `Task[]`
- `backend/src/controllers/taskController.ts` — calls the service and sends the JSON response
- `backend/src/routes/tasks.ts` — Express router wiring `GET /` to the controller

### Modified files
- `backend/src/app.ts` — mounts the tasks router at `/api/v1/tasks`

## Testing

- Manual testing: `GET /api/v1/tasks` returns `{ success: true, data: [] }` after running `npm run dev`
- TypeScript: no errors

## Acceptance criteria
- [x] `GET /api/v1/tasks` responds with `{ success: true, data: [] }`
- [x] Logic separated into service, controller, and router layers
- [x] TypeScript: no errors