### PR TITLE
feat(backend): add Prisma schema with User, Task, and Status

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "backend",
       "version": "1.0.0",
       "dependencies": {
+        "@prisma/client": "^7.8.0",
         "express": "^4.18.2"
       },
       "devDependencies": {
@@ -1296,6 +1297,36 @@
       "dependencies": {
         "@noble/hashes": "^1.1.5"
       }
+    },
+    "node_modules/@prisma/client": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.8.0.tgz",
+      "integrity": "sha512-HFp3Dawv/3sU3JtlPha90IB+48lS7zHiH4LKZPjmcE8YH5P9DOXGPvo8dqOtO7MqLDd1p2hOWMcFlRT1DMblHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/client-runtime-utils": "7.8.0"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24.0"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/client-runtime-utils": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.8.0.tgz",
+      "integrity": "sha512-5NQZztQ0oY/ADFkmd9gPuweH5A1/CCY8YQPorLLO0Mu6a87mY5gsnDkzmFmIHs9NFaLnZojzgddFVN4RpKYrdw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.17",
@@ -7260,7 +7291,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@prisma/client": "^7.8.0",
     "express": "^4.18.2"
   },
   "devDependencies": {

--- a/backend/prisma.config.ts
+++ b/backend/prisma.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "prisma/config";
+
+export default defineConfig({
+  datasourceUrl: process.env.DATABASE_URL,
+});

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,30 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+}
+
+enum Status {
+  TODO
+  IN_PROGRESS
+  DONE
+}
+
+model User {
+  id        String   @id @default(uuid())
+  name      String
+  email     String   @unique
+  createdAt DateTime @default(now())
+  tasks     Task[]
+}
+
+model Task {
+  id        String    @id @default(uuid())
+  title     String
+  completed Boolean   @default(false)
+  dueDate   DateTime?
+  userId    String
+  user      User      @relation(fields: [userId], references: [id])
+}


### PR DESCRIPTION
## What does this PR do?

Introduces a Prisma schema with `User` and `Task` models matching the existing TypeScript types, a `Status` enum, and a one-to-many relation between users and tasks. Also adds the `@prisma/client` dependency and a `prisma.config.ts` to wire up the database URL.

Closes #12

## Changes

### New files
- `backend/prisma/schema.prisma` — `User`, `Task` models, `Status` enum, and User→Task relation
- `backend/prisma.config.ts` — Prisma config reading `DATABASE_URL` from env

### Modified files
- `backend/package.json` — added `@prisma/client` dependency

## Acceptance criteria
- [x] `User` model: id, name, email (unique), createdAt
- [x] `Task` model: id, title, completed, optional dueDate, userId foreign key
- [x] `Status` enum: `TODO`, `IN_PROGRESS`, `DONE`
- [x] One-to-many relation: `User.tasks` → `Task[]`