### PR TITLE
feat(docker): add Dockerfiles, compose, and fix TS import errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "eslint.workingDirectories": ["backend"]
+}

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+EXPOSE 3000
+
+CMD ["node", "dist/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: impact
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  backend:
+    build: ./backend
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/impact
+      PORT: 3000
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+
+  frontend:
+    build: ./frontend
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend
+
+volumes:
+  db_data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Task } from "./types";
+import type { Task } from "./types";
 import TaskCard from "./TaskCard";
 
 const initialTasks: Task[] = [

--- a/frontend/src/TaskCard.tsx
+++ b/frontend/src/TaskCard.tsx
@@ -1,4 +1,4 @@
-import { Task } from "./types";
+import type { Task } from "./types";
 
 interface TaskCardProps {
   task: Task;


### PR DESCRIPTION
## What does this PR do?

Containerizes the full stack with Dockerfiles for both frontend and backend, a root-level `docker-compose.yml` wiring up `db`, `backend`, and `frontend` services, and `.dockerignore` files for each. Also fixes TypeScript `verbatimModuleSyntax` import errors in the frontend and adds a VS Code ESLint working directory setting.

Closes #13

## Changes

### New files
- `backend/Dockerfile` — installs deps, builds TypeScript, starts with `node dist/index.js`
- `backend/.dockerignore` — excludes `node_modules`, `dist`, `.env`
- `frontend/Dockerfile` — installs deps, starts Vite dev server with `--host`
- `frontend/.dockerignore` — excludes `node_modules`, `dist`, `.env`
- `docker-compose.yml` — wires `db` (Postgres), `backend`, and `frontend` with a `db_data` volume
- `.vscode/settings.json` — sets ESLint working directory to `backend/`

### Modified files
- `frontend/src/App.tsx` — changed to `import type` for `Task` (verbatimModuleSyntax)
- `frontend/src/TaskCard.tsx` — changed to `import type` for `Task` (verbatimModuleSyntax)

## Testing

- Manual testing: `docker compose up --build` runs all three services successfully
- Frontend accessible at `http://localhost:5173`
- Backend accessible at `http://localhost:3000/api/v1/tasks`

## Acceptance criteria
- [x] All three services start with `docker compose up --build`
- [x] `.dockerignore` excludes `node_modules`, `dist`, `.env`
- [x] `db_data` volume persists Postgres data
- [x] TypeScript: no errors in frontend
- [x] VS Code ESLint working directory error resolved