### PR TITLE
feat(railway): add frontend railway.toml and fix backend start command

### DIFF
--- a/frontend/railway.toml
+++ b/frontend/railway.toml
@@ -1,0 +1,8 @@
+[build]
+builder = "nixpacks"
+buildCommand = "npm ci && npm run build"
+
+[deploy]
+startCommand = "npx vite preview --host 0.0.0.0 --port $PORT"
+healthcheckPath = "/"
+healthcheckTimeout = 60

--- a/railway.toml
+++ b/railway.toml
@@ -6,4 +6,4 @@ dockerfilePath = "backend/Dockerfile"
 [deploy]
 healthcheckPath = "/health"
 healthcheckTimeout = 300
-startCommand = "npx prisma migrate deploy && node dist/server.js"
+startCommand = "npx prisma migrate deploy && node dist/index.js"


### PR DESCRIPTION
## What does this PR do?

Adds the missing `frontend/railway.toml` so Railway can build and deploy the Vite/React frontend as a separate service. Also fixes a bug in the existing root `railway.toml` where the backend start command referenced the wrong entry point (`dist/server.js` → `dist/index.js`).

Closes #21

## Changes

### New files
- `frontend/railway.toml` — nixpacks build config and vite preview deploy for the frontend service

### Modified files
- `railway.toml` — fixed `startCommand`: `dist/server.js` → `dist/index.js` to match `backend/package.json` and the Dockerfile CMD

## Testing

- No unit tests applicable (config-only change)
- Manual testing: file contents verified against acceptance criteria

## Acceptance criteria
- [x] `railway.toml` exists at repo root with correct build and deploy config for the backend service
- [x] `frontend/railway.toml` exists with correct build and deploy config for the frontend service