### PR TITLE
issue 43 - see comments for explanation of what was changed

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.2.5",
-        "react-dom": "^19.2.5"
+        "react-dom": "^19.2.5",
+        "react-router-dom": "^7.15.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -27,6 +28,9 @@
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.2",
         "vite": "^8.0.10"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1521,6 +1525,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -3037,6 +3054,44 @@
         "react": "^19.2.5"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
+      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
+      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.15.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -3186,6 +3241,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
   },
   "dependencies": {
     "react": "^19.2.5",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "react-router-dom": "^7.15.0"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,27 +1,23 @@
-import { useState } from "react";
-import type { Task } from "./types";
-import TaskCard from "./TaskCard";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import LoginPage from "./pages/LoginPage";
+import RegisterPage from "./pages/RegisterPage";
+import DashboardPage from "./pages/DashboardPage";
 
-const initialTasks: Task[] = [
-  { id: "1", title: "Set up the project", completed: true },
-  { id: "2", title: "Build the TaskCard component", completed: true },
-  { id: "3", title: "Connect to the backend", completed: false },
-];
+function PublicRoute({ children }: { children: React.ReactNode }) {
+  const isAuthenticated = !!localStorage.getItem("token");
+  return isAuthenticated ? <Navigate to="/dashboard" replace /> : <>{children}</>;
+}
 
 function App() {
-  const [tasks] = useState<Task[]>(initialTasks);
-
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold text-gray-900 mb-4">Impact Training</h1>
-        <div className="mt-6 flex flex-col gap-3 text-left">
-          {tasks.map((task) => (
-            <TaskCard key={task.id} task={task} />
-          ))}
-        </div>
-      </div>
-    </div>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/login" element={<PublicRoute><LoginPage /></PublicRoute>} />
+        <Route path="/register" element={<PublicRoute><RegisterPage /></PublicRoute>} />
+        <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="*" element={<Navigate to="/login" replace />} />
+      </Routes>
+    </BrowserRouter>
   );
 }
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,31 @@
+export async function register(name: string, email: string, password: string) {
+  const res = await fetch("/api/auth/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, email, password }),
+  });
+
+  const data = await res.json();
+
+  if (!res.ok) {
+    throw new Error(data.error ?? "Registration failed");
+  }
+
+  return data.data as { token: string; user: { id: string; name: string; email: string } };
+}
+
+export async function login(email: string, password: string) {
+  const res = await fetch("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+
+  const data = await res.json();
+
+  if (!res.ok) {
+    throw new Error(data.error ?? "Login failed");
+  }
+
+  return data.data as { token: string; user: { id: string; name: string; email: string } };
+}

--- a/frontend/src/pages/AuthLayout.tsx
+++ b/frontend/src/pages/AuthLayout.tsx
@@ -1,0 +1,22 @@
+import { Link } from "react-router-dom";
+
+interface AuthLayoutProps {
+  children: React.ReactNode;
+  toggle: { label: string; linkText: string; to: string };
+}
+
+export default function AuthLayout({ children, toggle }: AuthLayoutProps) {
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-8 w-full max-w-sm">
+        {children}
+        <p className="mt-6 text-center text-sm text-gray-500">
+          {toggle.label}{" "}
+          <Link to={toggle.to} className="text-blue-600 font-medium hover:underline">
+            {toggle.linkText}
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,7 @@
+export default function DashboardPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+      <p className="text-gray-500 text-sm">Dashboard — coming soon</p>
+    </div>
+  );
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,92 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { login } from "../api/auth";
+import AuthLayout from "./AuthLayout";
+
+export default function LoginPage() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<{ email?: string; password?: string }>({});
+  const [submitError, setSubmitError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  function validate() {
+    const errors: { email?: string; password?: string } = {};
+    if (!email.trim()) errors.email = "Email is required";
+    if (!password) errors.password = "Password is required";
+    return errors;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitError("");
+
+    const errors = validate();
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    setFieldErrors({});
+    setLoading(true);
+
+    try {
+      const { token } = await login(email, password);
+      localStorage.setItem("token", token);
+      navigate("/dashboard");
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Login failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <AuthLayout toggle={{ label: "Don't have an account?", linkText: "Sign up", to: "/register" }}>
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">Sign in</h1>
+
+      <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="email" className="text-sm font-medium text-gray-700">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className={`border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${fieldErrors.email ? "border-red-400" : "border-gray-300"}`}
+          />
+          {fieldErrors.email && <p className="text-xs text-red-600">{fieldErrors.email}</p>}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="password" className="text-sm font-medium text-gray-700">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className={`border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${fieldErrors.password ? "border-red-400" : "border-gray-300"}`}
+          />
+          {fieldErrors.password && <p className="text-xs text-red-600">{fieldErrors.password}</p>}
+        </div>
+
+        {submitError && <p className="text-sm text-red-600">{submitError}</p>}
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="bg-blue-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {loading ? "Signing in…" : "Sign in"}
+        </button>
+      </form>
+    </AuthLayout>
+  );
+}

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,0 +1,142 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { register } from "../api/auth";
+import AuthLayout from "./AuthLayout";
+
+type FieldErrors = {
+  name?: string;
+  email?: string;
+  password?: string;
+  confirmPassword?: string;
+};
+
+export default function RegisterPage() {
+  const navigate = useNavigate();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [submitError, setSubmitError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  function validate(): FieldErrors {
+    const errors: FieldErrors = {};
+    if (!name.trim()) errors.name = "Name is required";
+    if (!email.trim()) errors.email = "Email is required";
+    if (!password) errors.password = "Password is required";
+    if (!confirmPassword) {
+      errors.confirmPassword = "Please confirm your password";
+    } else if (password !== confirmPassword) {
+      errors.confirmPassword = "Passwords do not match";
+    }
+    return errors;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setSubmitError("");
+
+    const errors = validate();
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    setFieldErrors({});
+    setLoading(true);
+
+    try {
+      const { token } = await register(name, email, password);
+      localStorage.setItem("token", token);
+      navigate("/dashboard");
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Registration failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const inputClass = (hasError: boolean) =>
+    `border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${hasError ? "border-red-400" : "border-gray-300"}`;
+
+  return (
+    <AuthLayout toggle={{ label: "Already have an account?", linkText: "Sign in", to: "/login" }}>
+      <h1 className="text-2xl font-bold text-gray-900 mb-6">Create account</h1>
+
+      <form onSubmit={handleSubmit} noValidate className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <label htmlFor="name" className="text-sm font-medium text-gray-700">
+            Name
+          </label>
+          <input
+            id="name"
+            type="text"
+            autoComplete="name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className={inputClass(!!fieldErrors.name)}
+          />
+          {fieldErrors.name && <p className="text-xs text-red-600">{fieldErrors.name}</p>}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="email" className="text-sm font-medium text-gray-700">
+            Email
+          </label>
+          <input
+            id="email"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className={inputClass(!!fieldErrors.email)}
+          />
+          {fieldErrors.email && <p className="text-xs text-red-600">{fieldErrors.email}</p>}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="password" className="text-sm font-medium text-gray-700">
+            Password
+          </label>
+          <input
+            id="password"
+            type="password"
+            autoComplete="new-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className={inputClass(!!fieldErrors.password)}
+          />
+          {fieldErrors.password && <p className="text-xs text-red-600">{fieldErrors.password}</p>}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label htmlFor="confirmPassword" className="text-sm font-medium text-gray-700">
+            Confirm password
+          </label>
+          <input
+            id="confirmPassword"
+            type="password"
+            autoComplete="new-password"
+            value={confirmPassword}
+            onChange={(e) => setConfirmPassword(e.target.value)}
+            className={inputClass(!!fieldErrors.confirmPassword)}
+          />
+          {fieldErrors.confirmPassword && (
+            <p className="text-xs text-red-600">{fieldErrors.confirmPassword}</p>
+          )}
+        </div>
+
+        {submitError && <p className="text-sm text-red-600">{submitError}</p>}
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="bg-blue-600 text-white rounded-lg px-4 py-2 text-sm font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {loading ? "Creating account…" : "Create account"}
+        </button>
+      </form>
+    </AuthLayout>
+  );
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,5 +6,8 @@ export default defineConfig({
   plugins: [react()],
   server: {
     allowedHosts: ['code-impact-trainingfrontend-development.up.railway.app'],
+    proxy: {
+      '/api': 'http://localhost:3000',
+    },
   },
 })


### PR DESCRIPTION
Here's a summary of every file touched in this session:

[frontend/src/App.tsx](vscode-webview://10a9juh9p16flbios5jr5ksn5v3e58rh454qsk9dufbvkvq2bo4o/frontend/src/App.tsx)

Added /register route pointing to RegisterPage
Added /dashboard route pointing to DashboardPage
Added PublicRoute wrapper that redirects authenticated users (token in localStorage) away from /login and /register to /dashboard
[frontend/src/pages/LoginPage.tsx](vscode-webview://10a9juh9p16flbios5jr5ksn5v3e58rh454qsk9dufbvkvq2bo4o/frontend/src/pages/LoginPage.tsx)

Replaced the single error state with fieldErrors (per-field) and submitError (API errors)
Added validate() — checks for empty email/password before the API call
Added noValidate on the form to suppress browser-native validation UI
Inputs turn red-bordered and show an inline message when their field has an error
Wrapped in AuthLayout with a "Don't have an account? Sign up" toggle link
[frontend/src/pages/RegisterPage.tsx](vscode-webview://10a9juh9p16flbios5jr5ksn5v3e58rh454qsk9dufbvkvq2bo4o/frontend/src/pages/RegisterPage.tsx) (new file)

Form with Name, Email, Password, and Confirm Password fields
Per-field validation: all fields required; confirm password checks for mismatch
Same error display pattern as LoginPage (red border + inline message per field)
On success: stores JWT in localStorage, redirects to /dashboard
Wrapped in AuthLayout with an "Already have an account? Sign in" toggle link
[frontend/src/pages/AuthLayout.tsx](vscode-webview://10a9juh9p16flbios5jr5ksn5v3e58rh454qsk9dufbvkvq2bo4o/frontend/src/pages/AuthLayout.tsx) (new file)

Shared card container used by both LoginPage and RegisterPage
Renders a toggle link at the bottom using React Router's <Link> (client-side navigation, no full page reload)
[frontend/src/pages/DashboardPage.tsx](vscode-webview://10a9juh9p16flbios5jr5ksn5v3e58rh454qsk9dufbvkvq2bo4o/frontend/src/pages/DashboardPage.tsx) (new file)

Minimal placeholder so the post-auth redirect to /dashboard has a valid route to land on
[frontend/src/api/auth.ts](vscode-webview://10a9juh9p16flbios5jr5ksn5v3e58rh454qsk9dufbvkvq2bo4o/frontend/src/api/auth.ts)

Added register(name, email, password) — POSTs to /api/auth/register and returns { token, user }
Existing login function unchanged