### PR TITLE
feat/46 protected route system

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,6 +6,7 @@ COPY package*.json ./
 RUN npm ci
 
 COPY . .
+RUN npx prisma generate
 RUN npm run build
 
 EXPOSE 3000

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { AuthProvider, useAuth } from "./context/AuthContext";
+import PrivateRoute from "./components/PrivateRoute";
 import LoginPage from "./pages/LoginPage";
 import RegisterPage from "./pages/RegisterPage";
 import DashboardPage from "./pages/DashboardPage";
@@ -9,25 +11,27 @@ import ProfilePage from "./pages/ProfilePage";
 import AppLayout from "./layouts/AppLayout";
 
 function PublicRoute({ children }: { children: React.ReactNode }) {
-  const isAuthenticated = !!localStorage.getItem("token");
-  return isAuthenticated ? <Navigate to="/dashboard" replace /> : <>{children}</>;
+  const { token } = useAuth();
+  return token ? <Navigate to="/dashboard" replace /> : <>{children}</>;
 }
 
 function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/login" element={<PublicRoute><LoginPage /></PublicRoute>} />
-        <Route path="/register" element={<PublicRoute><RegisterPage /></PublicRoute>} />
-        <Route element={<AppLayout />}>
-          <Route path="/dashboard" element={<DashboardPage />} />
-          <Route path="/calendar" element={<CalendarPage />} />
-          <Route path="/tasks" element={<TasksPage />} />
-          <Route path="/reminders" element={<RemindersPage />} />
-          <Route path="/profile" element={<ProfilePage />} />
-        </Route>
-        <Route path="*" element={<Navigate to="/login" replace />} />
-      </Routes>
+      <AuthProvider>
+        <Routes>
+          <Route path="/login" element={<PublicRoute><LoginPage /></PublicRoute>} />
+          <Route path="/register" element={<PublicRoute><RegisterPage /></PublicRoute>} />
+          <Route element={<PrivateRoute><AppLayout /></PrivateRoute>}>
+            <Route path="/dashboard" element={<DashboardPage />} />
+            <Route path="/calendar" element={<CalendarPage />} />
+            <Route path="/tasks" element={<TasksPage />} />
+            <Route path="/reminders" element={<RemindersPage />} />
+            <Route path="/profile" element={<ProfilePage />} />
+          </Route>
+          <Route path="*" element={<Navigate to="/login" replace />} />
+        </Routes>
+      </AuthProvider>
     </BrowserRouter>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { AuthProvider, useAuth } from "./context/AuthContext";
 import PrivateRoute from "./components/PrivateRoute";
@@ -12,7 +13,11 @@ import AppLayout from "./layouts/AppLayout";
 
 function PublicRoute({ children }: { children: React.ReactNode }) {
   const { token } = useAuth();
-  return token ? <Navigate to="/dashboard" replace /> : <>{children}</>;
+  // Only redirect if the user was already authenticated when this component mounted.
+  // If token becomes truthy during this render (i.e. they just logged in), let
+  // LoginPage's navigate() handle the destination instead of hardcoding /dashboard.
+  const [wasAuthOnMount] = useState(() => !!token);
+  return wasAuthOnMount && token ? <Navigate to="/dashboard" replace /> : <>{children}</>;
 }
 
 function App() {

--- a/frontend/src/components/PrivateRoute.tsx
+++ b/frontend/src/components/PrivateRoute.tsx
@@ -1,0 +1,21 @@
+import { Navigate, useLocation } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+
+export default function PrivateRoute({ children }: { children: React.ReactNode }) {
+  const { token } = useAuth();
+  const location = useLocation();
+
+  // Also check localStorage: React Router's useSyncExternalStore forces a sync
+  // re-render on navigate() before AuthContext's setToken has committed, so the
+  // context token can be null for one render even though localStorage is already set.
+  if (!token && !localStorage.getItem("token")) {
+    return (
+      <Navigate
+        to={`/login?redirect=${encodeURIComponent(location.pathname)}`}
+        replace
+      />
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,64 @@
+import { createContext, useContext, useState, useCallback, useEffect } from "react";
+import { registerLogout } from "../lib/api";
+
+type User = { id: string; name: string; email: string };
+
+type AuthContextValue = {
+  token: string | null;
+  user: User | null;
+  login: (token: string, user: User) => void;
+  logout: () => void;
+};
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState<string | null>(() => localStorage.getItem("token"));
+  const [user, setUser] = useState<User | null>(() => {
+    try {
+      const stored = localStorage.getItem("user");
+      return stored ? (JSON.parse(stored) as User) : null;
+    } catch {
+      return null;
+    }
+  });
+
+  const logout = useCallback(() => {
+    localStorage.removeItem("token");
+    localStorage.removeItem("user");
+    setToken(null);
+    setUser(null);
+  }, []);
+
+  function login(newToken: string, newUser: User) {
+    localStorage.setItem("token", newToken);
+    localStorage.setItem("user", JSON.stringify(newUser));
+    setToken(newToken);
+    setUser(newUser);
+  }
+
+  useEffect(() => {
+    registerLogout(logout);
+  }, [logout]);
+
+  // Sync state if token is cleared from another tab or devtools
+  useEffect(() => {
+    function handleStorage(e: StorageEvent) {
+      if (e.key === "token" && !e.newValue) logout();
+    }
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, [logout]);
+
+  return (
+    <AuthContext.Provider value={{ token, user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used inside AuthProvider");
+  return ctx;
+}

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -57,6 +57,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useAuth() {
   const ctx = useContext(AuthContext);
   if (!ctx) throw new Error("useAuth must be used inside AuthProvider");

--- a/frontend/src/layouts/AppLayout.tsx
+++ b/frontend/src/layouts/AppLayout.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { NavLink, Outlet } from "react-router-dom";
+import { NavLink, Outlet, useNavigate } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
 
 const navItems = [
   { to: "/dashboard", label: "Dashboard" },
@@ -10,8 +11,16 @@ const navItems = [
 ];
 
 function Sidebar({ onClose }: { onClose?: () => void }) {
+  const navigate = useNavigate();
+  const { logout } = useAuth();
+
   function handleNavClick() {
     onClose?.();
+  }
+
+  function handleLogout() {
+    logout();
+    navigate("/login", { replace: true });
   }
 
   return (
@@ -37,6 +46,14 @@ function Sidebar({ onClose }: { onClose?: () => void }) {
           </NavLink>
         ))}
       </nav>
+      <div className="px-3 py-4 border-t border-gray-200 shrink-0">
+        <button
+          onClick={handleLogout}
+          className="w-full px-3 py-2 rounded-lg text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 text-left"
+        >
+          Sign out
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,29 @@
+type LogoutFn = () => void;
+
+let onLogout: LogoutFn | null = null;
+
+export function registerLogout(fn: LogoutFn) {
+  onLogout = fn;
+}
+
+export async function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const token = localStorage.getItem("token");
+
+  const headers = new Headers(init.headers as HeadersInit);
+  if (!headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  const res = await fetch(path, { ...init, headers });
+
+  if (res.status === 401) {
+    onLogout?.();
+    const redirect = encodeURIComponent(window.location.pathname);
+    window.location.replace(`/login?redirect=${redirect}`);
+  }
+
+  return res;
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,10 +1,13 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { login } from "../api/auth";
+import { useAuth } from "../context/AuthContext";
 import AuthLayout from "./AuthLayout";
 
 export default function LoginPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { login: authLogin } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [fieldErrors, setFieldErrors] = useState<{ email?: string; password?: string }>({});
@@ -32,9 +35,10 @@ export default function LoginPage() {
     setLoading(true);
 
     try {
-      const { token } = await login(email, password);
-      localStorage.setItem("token", token);
-      navigate("/dashboard");
+      const { token, user } = await login(email, password);
+      authLogin(token, user);
+      const redirect = searchParams.get("redirect");
+      navigate(redirect ?? "/dashboard", { replace: true });
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : "Login failed");
     } finally {

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { register } from "../api/auth";
+import { useAuth } from "../context/AuthContext";
 import AuthLayout from "./AuthLayout";
 
 type FieldErrors = {
@@ -12,6 +13,7 @@ type FieldErrors = {
 
 export default function RegisterPage() {
   const navigate = useNavigate();
+  const { login: authLogin } = useAuth();
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -47,9 +49,9 @@ export default function RegisterPage() {
     setLoading(true);
 
     try {
-      const { token } = await register(name, email, password);
-      localStorage.setItem("token", token);
-      navigate("/dashboard");
+      const { token, user } = await register(name, email, password);
+      authLogin(token, user);
+      navigate("/dashboard", { replace: true });
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : "Registration failed");
     } finally {


### PR DESCRIPTION
## Summary
- Adds `AuthContext` with centralized `token`/`user` state, `login`, and `logout` helpers
- Adds `PrivateRoute` component that guards all authenticated routes and redirects unauthenticated users to `/login?redirect=<path>`
- Adds `lib/api.ts` shared fetch wrapper that attaches Bearer tokens and globally intercepts 401 responses
- Updates `LoginPage` to honor `?redirect` param after login so users land on their original destination
- Adds Sign out button to the sidebar
- Fixes backend Dockerfile to run `prisma generate` before `tsc` so the build no longer fails with missing `PrismaClient` types

## Test plan
- [ ] Clear localStorage and navigate to `/dashboard` — redirected to `/login`
- [ ] Log in from `/login?redirect=/calendar` — lands on `/calendar` after auth
- [ ] Manually delete token from localStorage while on dashboard — next API call triggers redirect to `/login`
- [ ] Visit `/login` while logged in — redirected to `/dashboard`
- [ ] Sign out button in sidebar clears session and redirects to `/login`
- [ ] Verify backend deploys successfully on Railway (Dockerfile fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)