### PR TITLE
chore: point vite dev proxy to railway backend

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   server: {
     allowedHosts: ['code-impact-trainingfrontend-development.up.railway.app'],
     proxy: {
-      '/api': 'http://localhost:3000',
+      '/api': 'https://code-impact-trainingbackend-development.up.railway.app',
     },
   },
 })


### PR DESCRIPTION
Fix dev login hang by pointing Vite proxy to Railway backend instead of localhost:3000